### PR TITLE
Add "cursor: move" to the draggable items

### DIFF
--- a/assets/profile.css
+++ b/assets/profile.css
@@ -133,6 +133,7 @@ ul li {
 	-webkit-border-radius: 10px;
 	color:#fff;
 	background-color: #000; 
+	cursor: move;
 }
 
 .setupbox {


### PR DESCRIPTION
From [a HN comment](https://news.ycombinator.com/item?id=6202169):

<blockquote>
Please add "cursor: default;" or "cursor: move;" to the draggable items. Draggable things should not use the text selection cursor. :)
</blockquote>
