### PR TITLE
Add "cursor: move" to the draggable items and "cursor: pointer" to the selectable items

### DIFF
--- a/assets/profile.css
+++ b/assets/profile.css
@@ -133,6 +133,7 @@ ul li {
 	-webkit-border-radius: 10px;
 	color:#fff;
 	background-color: #000; 
+	cursor: move;
 }
 
 .setupbox {
@@ -224,6 +225,8 @@ color pick Box
 
 #colorpick > ul > li {
 	background-color: #111;
+	cursor: pointer;
+	cursor: hand;
 }
 
 #colorpick > ul > li:after {


### PR DESCRIPTION
From [a HN comment](https://news.ycombinator.com/item?id=6202169):

<blockquote>
Please add "cursor: default;" or "cursor: move;" to the draggable items. Draggable things should not use the text selection cursor. :)
</blockquote>


This corrects [a previous pull request ](https://github.com/xta/HalloweenBash/pull/12) where I forgot to put `cursor: pointer` for the non-draggable list items.
