### PR TITLE
Fix issue #15.

### DIFF
--- a/assets/profile.css
+++ b/assets/profile.css
@@ -117,6 +117,7 @@ h2 {
 }
 
 ul {
+	min-height: 30px;
 	margin: 0 0 10px 20px;
 }
 


### PR DESCRIPTION
When emptied, `Your Configuration` box became unaccessible. Adding a simple `min-height` to it solved the problem.
