### PR TITLE
Escape $

### DIFF
--- a/assets/profile.js
+++ b/assets/profile.js
@@ -322,7 +322,7 @@ $(document).ready(function() {
 		},
 		"psdollar": {
 					         text_id: "psdollar", 
-					     bash_string: "$ ", 
+					     bash_string: "\\$ ", 
 					    example_copy: "$&nbsp;", 
 					long_description: "dollar sign"
 		},


### PR DESCRIPTION
Escape $ to make sure it becomes a # when switching to root.

(When using single quotes for PS1 a single \ would be enough.)
